### PR TITLE
m2cgen 0.10.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,6 +12,7 @@ source:
 
 build:
   number: 0
+  skip: true  # [py<37]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   entry_points:
     - m2cgen = m2cgen.cli:main
@@ -41,7 +42,8 @@ about:
   dev_url: https://github.com/BayesWitnesses/m2cgen
   doc_url: https://github.com/BayesWitnesses/m2cgen
   summary: Code-generation for various ML models into native code.
-  description: Code-generation for various ML models into native code.
+  description: |
+    m2cgen (Model 2 Code Generator) - is a lightweight library which provides an easy way to transpile trained statistical models into a native code (Python, C, Java, Go, JavaScript, Visual Basic, C#, PowerShell, R, PHP, Dart, Haskell, Ruby, F#, Rust, Elixir).
   license: MIT
   license_family: MIT
   license_file: LICENSE

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,38 +7,43 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/m2cgen-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: 9adfc5c6e693b1bb2e757c379e14ff97c95d1a11f9f6536882ebd7e402d34aa8
 
 build:
   number: 0
-  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   entry_points:
     - m2cgen = m2cgen.cli:main
-  script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
   host:
     - pip
-    - python >=3.7
+    - python
+    - setuptools
+    - wheel
   run:
+    - python
     - numpy
-    - python >=3.7
 
 test:
   imports:
     - m2cgen
     - m2cgen.assemblers
+  requires:
+    - pip
   commands:
     - pip check
     - m2cgen --help
-  requires:
-    - pip
 
 about:
   home: https://github.com/BayesWitnesses/m2cgen
+  dev_url: https://github.com/BayesWitnesses/m2cgen
+  doc_url: https://github.com/BayesWitnesses/m2cgen
   summary: Code-generation for various ML models into native code.
+  description: Code-generation for various ML models into native code.
   license: MIT
+  license_family: MIT
   license_file: LICENSE
 
 extra:


### PR DESCRIPTION
Changelog: https://github.com/BayesWitnesses/m2cgen/releases
License: https://github.com/BayesWitnesses/m2cgen/blob/v0.10.0/LICENSE
Requirements: https://github.com/BayesWitnesses/m2cgen/blob/v0.10.0/setup.py

Actions:
1. Remove `noarch python`
2. Skip py<37
3. Add flags `--no-deps --no-build-isolation` to `script`
4. Add missing `setuptools` and `wheel` to `host`
5. Fix `python` in `host` and `run`
6. Add `description` 
7. Add dev & doc urls
8. Add license_family

Notes:
- pycaret 3.0.2 (subpackage pycaret-mlops) relies on it https://github.com/pycaret/pycaret/blob/fdc3f7d22a4117577340be6d8fe2db2a889e9d82/requirements-optional.txt#L34